### PR TITLE
Increase api_key max length

### DIFF
--- a/split/resource_split_api_key.go
+++ b/split/resource_split_api_key.go
@@ -43,7 +43,7 @@ func resourceSplitApiKey() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 15),
+				ValidateFunc: validation.StringLenBetween(1, 100),
 			},
 
 			"type": {


### PR DESCRIPTION
SDK API key has limit of 100 characters, not 15:

<img width="976" alt="463512173-0486f8d9-24bd-47bf-8a87-fbe5deebe9a2" src="https://github.com/user-attachments/assets/ebad12aa-c321-4d34-9f27-6696936b4425" />
